### PR TITLE
Fix exports and export assignments are not permitted in module augmentations

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -51,7 +51,7 @@ declare module 'clearx' {
         teardown(): boolean
     }
 
-    class ClearX {
+    export default class ClearX {
         constructor (data: JsonObject)
         get(key: path, defaultValue?: any): any
         set(key: path, value: any, doNotReplace?: boolean): boolean
@@ -81,6 +81,4 @@ declare module 'clearx' {
         teardown(): boolean
     }
 
-    export default ClearX
-    
 }


### PR DESCRIPTION
Fix TypeScript issue TS2666: "Exports and export assignments are not permitted in module augmentations"